### PR TITLE
fix: avoid regex escape in status block

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.29] - 2025-09-02
+- Guarded status block replacement with a callable to avoid backslash escapes.
+- Added tool execution safety with timeout and concurrency limits.
+- Rendered neutral tool status for unnamed tool calls.
+- Adapted to various API transfer stations.
+
 ## [0.8.28] - 2025-08-21
 - Resolved compatibility with Open WebUI v0.6.23 by awaiting `__tools__` when
   it is provided as a coroutine.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -5,7 +5,7 @@ author: Justin Kropp (original), frondesce (community mod)
 contributors: GPT-5 Thinking (AI assistance)
 source: https://github.com/jrkropp/open-webui-developer-toolkit
 license: MIT
-version: 0.8.24
+version: 0.8.29
 description: Adds GPT-5 Responses API support (text.verbosity, reasoning.effort), streaming reasoning summary with throttling, “Thinking → 🧠”, and SSE fallback. Unofficial; credits retained.
 """
 
@@ -1796,7 +1796,7 @@ class ExpandableStatusIndicator:
     async def _render(self, assistant_message: str, emit: bool) -> str:
         block = self._render_status_block()
         full_msg = (
-            self._BLOCK_RE.sub(block, assistant_message, 1)
+            self._BLOCK_RE.sub(lambda _: block, assistant_message, 1)
             if self._BLOCK_RE.search(assistant_message)
             else f"{block}{assistant_message}"
         )


### PR DESCRIPTION
## Summary
- guard status block replacement with a callable to avoid backslash escapes
- document tool execution safety and neutral status handling in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md` *(fails: pytest: error: unrecognized arguments: --cov=functions --cov=tools --cov-report=term-missing --asyncio-mode=auto --cov=functions --cov-report=term-missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ef3e79f0832793d7616f0c91a6f1