### PR TITLE
Handle content filter responses in non-streaming loop

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.30] - 2025-09-06
+- Handled content-filtered responses by emitting an error and stopping processing.
+
 ## [0.8.29] - 2025-09-02
 - Guarded status block replacement with a callable to avoid backslash escapes.
 - Added tool execution safety with timeout and concurrency limits.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -5,7 +5,7 @@ author: Justin Kropp (original), frondesce (community mod)
 contributors: GPT-5 Thinking (AI assistance)
 source: https://github.com/jrkropp/open-webui-developer-toolkit
 license: MIT
-version: 0.8.29
+version: 0.8.30
 description: Adds GPT-5 Responses API support (text.verbosity, reasoning.effort), streaming reasoning summary with throttling, “Thinking → 🧠”, and SSE fallback. Unofficial; credits retained.
 """
 
@@ -1139,6 +1139,15 @@ class Pipe:
                     base_url=valves.BASE_URL,
                     valves=valves,
                 )
+
+                if response.get("status") == "incomplete":
+                    reason = response.get("incomplete_details", {}).get("reason")
+                    if reason == "content_filter":
+                        status_indicator._done = True
+                        await self._emit_error(
+                            event_emitter, "请求被内容过滤", done=True
+                        )
+                        return ""
 
                 items = response.get("output", [])
 


### PR DESCRIPTION
## Summary
- ensure `_run_nonstreaming_loop` stops when OpenAI marks response as incomplete due to content filter and show a visible error
- bump OpenAI Responses Manifold version to 0.8.30 and document change in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68bc11cfdd4083278a16ce7d7c8af26a