### PR TITLE
Handle content filter responses in non-streaming loop

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [0.8.30] - 2025-09-06
 - Handled content-filtered responses in streaming and non-streaming flows by emitting an error and stopping processing.
+- Finalized status indicators when non-streaming responses are blocked by content filters so pending spinners close correctly.
 
 ## [0.8.29] - 2025-09-02
 - Guarded status block replacement with a callable to avoid backslash escapes.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -1152,7 +1152,8 @@ class Pipe:
                 if response.get("status") == "incomplete":
                     reason = response.get("incomplete_details", {}).get("reason")
                     if reason == "content_filter":
-                        status_indicator._done = True
+                        if status_indicator._items:
+                            await status_indicator.finish(assistant_message)
                         await self._emit_error(
                             event_emitter, "Request was blocked by content filter", done=True
                         )


### PR DESCRIPTION
## Summary
- finalize pending status indicator when non-streaming responses are blocked by content filters so the UI stops spinning
- document fix in the changelog

## Testing
- `PYTHONPATH=. pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`
- `PYTHONPATH=. pytest .tests/test_openai_responses_manifold.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc173f434c832791e0291375c98563