### PR TITLE
Avoid double completion after streaming errors

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.30] - 2025-09-06
+- Avoided emitting duplicate completion events after errors by tracking an `errored` flag.
+
 ## [0.8.29] - 2025-09-02
 - Guarded status block replacement with a callable to avoid backslash escapes.
 - Added tool execution safety with timeout and concurrency limits.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -5,7 +5,7 @@ author: Justin Kropp (original), frondesce (community mod)
 contributors: GPT-5 Thinking (AI assistance)
 source: https://github.com/jrkropp/open-webui-developer-toolkit
 license: MIT
-version: 0.8.29
+version: 0.8.30
 description: Adds GPT-5 Responses API support (text.verbosity, reasoning.effort), streaming reasoning summary with throttling, “Thinking → 🧠”, and SSE fallback. Unofficial; credits retained.
 """
 
@@ -764,6 +764,7 @@ class Pipe:
         _EMIT_INTERVAL = 0.35  # ≥350ms refresh once
         _EMIT_MIN_CHARS = 80  # Add ≥80 characters and refresh again
         self._last_rendered_summary = ""  # Record rendered merged
+        errored = False
 
         try:
             for loop_idx in range(valves.MAX_FUNCTION_CALL_LOOPS):
@@ -1066,6 +1067,7 @@ class Pipe:
                     break
 
         except Exception as e:  # pragma: no cover
+            errored = True
             await self._emit_error(
                 event_emitter,
                 f"Error: {str(e)}",
@@ -1088,7 +1090,10 @@ class Pipe:
                         )
 
             await self._emit_completion(
-                event_emitter, content="", usage=total_usage, done=True
+                event_emitter,
+                content="",
+                usage=total_usage,
+                done=not errored,
             )
             logs_by_msg_id.clear()
             SessionLogger.logs.pop(SessionLogger.session_id.get(), None)


### PR DESCRIPTION
## Summary
- track error state in streaming loop to avoid double `chat:completion` done events
- bump OpenAI Responses Manifold version to 0.8.30
- document change in changelog

## Testing
- `PYTHONPATH=. pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68bc1a0b09948327a6d7ac2e4fa40f81