### PR TITLE
Finalize status indicators before content filter errors

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.30] - 2025-09-06
+- Finalized pending status indicators before emitting content filter errors.
+- Removed direct manipulation of internal status indicator state.
+
 ## [0.8.29] - 2025-09-02
 - Guarded status block replacement with a callable to avoid backslash escapes.
 - Added tool execution safety with timeout and concurrency limits.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -5,7 +5,7 @@ author: Justin Kropp (original), frondesce (community mod)
 contributors: GPT-5 Thinking (AI assistance)
 source: https://github.com/jrkropp/open-webui-developer-toolkit
 license: MIT
-version: 0.8.29
+version: 0.8.30
 description: Adds GPT-5 Responses API support (text.verbosity, reasoning.effort), streaming reasoning summary with throttling, “Thinking → 🧠”, and SSE fallback. Unofficial; credits retained.
 """
 
@@ -743,7 +743,6 @@ class Pipe:
         emitted_citations: list[dict] = []
 
         status_indicator = ExpandableStatusIndicator(event_emitter)
-        status_indicator._done = False
 
         model_family = re.sub(r"-\d{4}-\d{2}-\d{2}$", "", body.model)
         if body.model.startswith("gpt-5"):
@@ -1008,6 +1007,18 @@ class Pipe:
                     raise ValueError(
                         "No final response received from OpenAI Responses API."
                     )
+                reason = (final_response.get("status") or {}).get("reason")
+                if reason == "content_filter":
+                    if not status_indicator._done and status_indicator._items:
+                        assistant_message = await status_indicator.finish(
+                            assistant_message, emit=True
+                        )
+                    await self._emit_error(
+                        event_emitter,
+                        "Response was filtered due to content policy.",
+                        done=True,
+                    )
+                    return assistant_message
 
                 usage = final_response.get("usage", {})
                 if usage:
@@ -1116,7 +1127,6 @@ class Pipe:
         reasoning_map: dict[int, str] = {}
 
         status_indicator = ExpandableStatusIndicator(event_emitter)
-        status_indicator._done = False
 
         model_family = re.sub(r"-\d{4}-\d{2}-\d{2}$", "", body.model)
         if body.model.startswith("gpt-5"):
@@ -1139,6 +1149,18 @@ class Pipe:
                     base_url=valves.BASE_URL,
                     valves=valves,
                 )
+                reason = (response.get("status") or {}).get("reason")
+                if reason == "content_filter":
+                    if not status_indicator._done and status_indicator._items:
+                        assistant_message = await status_indicator.finish(
+                            assistant_message, emit=True
+                        )
+                    await self._emit_error(
+                        event_emitter,
+                        "Response was filtered due to content policy.",
+                        done=True,
+                    )
+                    return assistant_message
 
                 items = response.get("output", [])
 


### PR DESCRIPTION
## Summary
- finalize pending status blocks before emitting content filter errors in streaming and non-streaming loops
- avoid direct manipulation of `ExpandableStatusIndicator._done`
- bump OpenAI Responses Manifold to v0.8.30

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68bc19f07880832786374509fe9f4458